### PR TITLE
#2 Created dashboard and kanban pages with vue router

### DIFF
--- a/src/resources/js/App.vue
+++ b/src/resources/js/App.vue
@@ -1,9 +1,7 @@
 <template>
     <div class="flex" id="app">
 
-        <div class="text-indigo-500">This is a vue + tailwind + fontawesome test
-            <i class="fa fa-user"></i>
-        </div>
+        <router-view></router-view>
 
     </div>
 </template>

--- a/src/resources/js/app.js
+++ b/src/resources/js/app.js
@@ -1,9 +1,12 @@
 import Vue from "vue";
 import App from "./App.vue";
+import router from "./router";
+
 import "@fortawesome/fontawesome-free/js/all.js";
 
 Vue.config.productionTip = false;
 
 new Vue({
+    router,
     render: (h) => h(App)
 }).$mount("#app");

--- a/src/resources/js/components/dashboard/Dashboard.vue
+++ b/src/resources/js/components/dashboard/Dashboard.vue
@@ -1,0 +1,19 @@
+<template>
+    <div>
+        This is the dashboard page
+
+        <router-link :to="{ path: '/kanban/board', query: { id: 1 } }">
+            <span class="text-gray-700 bg-gray-50 p-2 m-2">Test Board 1</span>
+        </router-link>
+
+        <router-link :to="{ path: '/kanban/board', query: { id: 2 } }">
+            <span class="text-gray-700 bg-gray-50 p-2 m-2">Test Board 2</span>
+        </router-link>
+    </div>
+</template>
+
+<script>
+export default {
+};
+</script>
+

--- a/src/resources/js/components/kanban/Kanban.vue
+++ b/src/resources/js/components/kanban/Kanban.vue
@@ -1,0 +1,15 @@
+<template>
+    <div>
+        This is the kanban page showing board id:{{ id }}
+
+        <router-link :to="{ path: '/kanban' }">
+            <span class="text-gray-700 bg-gray-50 p-2 m-2">Go to dashboard</span>
+        </router-link>
+    </div>
+</template>
+
+<script>
+export default {
+    props: {'id': Number},
+};
+</script>

--- a/src/resources/js/router/index.js
+++ b/src/resources/js/router/index.js
@@ -1,0 +1,32 @@
+import Vue from "vue";
+import Router from "vue-router";
+import Kanban from "../components/kanban/Kanban";
+import Dashboard from "../components/dashboard/Dashboard";
+
+Vue.use(Router);
+
+export default new Router({
+    mode: "history",
+
+    routes: [
+        {
+            path: "/kanban/",
+            redirect: "kanban/dashboard"
+        },
+        {
+            path: "/kanban/dashboard",
+            component: Dashboard
+        },
+        {
+            path: "/kanban/board",
+            component: Kanban,
+            props: (route) => ({id: Number(route.query.id)})
+        },
+
+        // All invalid pages get re-routed to dashboard page
+        {
+            path: '*',
+            redirect: "kanban/dashboard"
+        }
+    ]
+});

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -2,6 +2,13 @@
 
     Route::group(['namespace' => 'SiamakSamie\Kanban\Http\Controllers',], function () {
         Route::group(['prefix' => 'kanban',], function () {
+
+            // We'll let vue router handle 404 (it will redirect to dashboard)
+            Route::fallback('KanbanController@getIndex');
+
+            // All view routes are handled by vue router
             Route::get('/', 'KanbanController@getIndex');
+            Route::get('/dashboard', 'KanbanController@getIndex');
+            Route::get('/board', 'KanbanController@getIndex');
         });
     });


### PR DESCRIPTION
Created routes to Kanban and Dashboard pages using Vue Router. This permits me to create a full website with routing capabilities without ever having to refresh the page.

I also did a test where I pass and get an property (an id) using one of the routes. This is important so that I can fetch the appropriate data and populate the page with it. 

I also, made the fallback for any non-existing URL entered to redirect to the dashboard page instead. 